### PR TITLE
Meeting minutes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ release = '1.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/meeting_notes.rst
+++ b/docs/meeting_notes.rst
@@ -1,8 +1,19 @@
-=============
-Meeting Notes
-=============
+===============================
+Executive Council Meeting Notes
+===============================
 
 .. toctree::
    :maxdepth: 1
 
    2023 Q1 <meeting_notes/2023_Q1>
+   2023 Q2 <meeting_notes/2023_Q2>
+
+==========================
+Office Hours Meeting Notes
+==========================
+
+.. toctree::
+   :maxdepth: 1
+
+   2023 Q1 <office_hours/2023_Q1>
+   2023 Q1 <office_hours/2023_Q2>

--- a/docs/meeting_notes/2023_Q1.md
+++ b/docs/meeting_notes/2023_Q1.md
@@ -1,1 +1,299 @@
 # Meeting Notes from 2023 Q1
+
+## 28 March 2023
+
+### Attendees
+- Afshin T. Darian
+- Ana Ruvalcaba
+- Steven Silvester
+- Jason Grout
+- Fernando Perez
+- Brian Granger
+
+### Decisions made
+- Steve and Ana bootstrap the Social Media Working Group as Editors-in-Chief. They will nominate a pool of Associate Editors to manage most individual decisions.
+    - They will create a draft of the charter/guidelines for social media and start the bootstrapping of people for that WG.
+
+### Agenda and minutes
+- JupyterCon travel funding update
+- Brief update on CoC committee
+    - CoC language hasn't been reviewed since its inception.
+    - Maybe worth reviewing/updating based on experience and evolution in this space.
+    - For JupyterCon, we'll be under the NF umbrella in this regard.
+    - As of this moment, any CoC issue would come to the EC.
+    - Given we're already using the NF one - could we potentially adopt it wholesale? It's an option to at least evaluate.
+    - Another suggestion from astropy (Moritz Gunther): NF create an ombuds office that supports individual projects that may struggle with CoC issues.
+- Update on social media working group
+- Update on permissions
+- DEI Charter feedback provided directly on the GH issue:
+  https://github.com/jupyter/executive-council-team-compass/issues/6
+
+---
+
+## 21 March 2023
+
+### Attendees
+- Afshin T. Darian
+- Ana Ruvalcaba
+- Steven Silvester
+- Jason Grout
+- Fernando Perez
+- Brian Granger
+
+### Decisions made
+- Communicate to EC+SSC that there is a meeting May 9 at JupyterCon, Tuesday afternoon, noon to after dinner, including lunch and dinner.
+- Offer to each subproject to designate a delegate if their SSC rep cannot come to the EC+SSC meeting. We can offer funding (if needed) for the delegate.
+- Update the passwords and authorized apps for our social media where possible (particularly Twitter) and start working on the policy that would be the seed of a charter.
+
+### Agenda and minutes
+- AI and ethics blog post
+- Leadership meeting / dinner at JupyterCon - what is scope?
+- Social media questions and sponsorship conversation to help shape a charter
+
+---
+
+## 14 March 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steven Silvester
+- Afshin T. Darian
+- Jason Grout
+- Brian Granger
+- Fernando Perez
+
+### Agenda and minutes
+- Open Collective (OC) Demo/Discussion notes
+    - It's possible to set up different accounting "areas" (not called "accounts" in OC lingo).
+    - Overwhelmingly positive response.
+    - There haven't been concerns over privacy or access to information from any of the projects using it.
+    - OC does not integrate with Quickbooks.
+    - High level summary
+        - OC provides not only a public view, but also input and communication capabilities for project
+
+---
+
+## 7 March 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steven Silvester
+- Jason Grout
+- Afshin T. Darian
+- Brian Granger
+- Fernando Pérez
+
+### Decisions made
+- Funding some JupyterCon participants
+- JupyterCon: Tuesday afternoon meeting and dinner
+- JupyterCon: 2024 - approved signing of contract for next year’s organizing committee and venue.
+
+### Agenda and minutes
+- Permissions audit of 1Password, Google Drive, and GitHub teams
+- Notebook Format Jupyter Community Workshop update
+- Built agenda for Friday meeting: Joint Meetings of the EC and SSC
+- JupyterCon special talks
+    - Notebook and Lab have official talks.
+
+---
+
+## 28 February 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steven Silvester
+- Fernando Pérez
+- Brian Granger
+- Afshin Darian
+
+### Decisions made
+- Fernando - send email to the security team about domains. Proposed scope of authority would be 1 EC member + 1 person from the infrastructure team.
+- New schedule for EC meetings selected.
+- Request NF join a future EC meeting: present and demo Open Collective. Consider this as a potential solution. If there is a write up or summary they’ve written this could be a good starting point
+
+### Agenda and minutes
+- DEI Charter - Jason W and Ana shared feedback with the others and this team will dedicate working time to an in depth review and revision of the proposed charter.
+- Community Building Working Group would like to conduct a community census. We’re working on a draft of what questions would be included. Besides a Team Compass and a mailing list what are the requirements of the subprojects? Do we have a central place where all the subproject info is listed?
+- Accessibility blog post
+
+---
+
+## 21 February 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steven Silvester
+- Fernando Pérez
+- Brian Granger
+- Jason Grout
+
+### Decisions made
+- Meeting notes should be public on team compass, except for private items highlighted to be filtered out.
+- Will start with one running document for now, we can make quarterly ones if a single one gets too long.
+- Publish every month or two a summary list of our active topics for that period, copied from our active task list.
+- Will send a survey looking for scheduling options for an EC/SSC meeting co-hosted at JupyterCon (either before or after the conference).
+
+### Agenda and minutes
+- EC Meeting minutes:
+    - The EC meeting minutes should in general be published on our team compass.
+    - Example minutes from the Python Steering Council: https://discuss.python.org/t/november-2022-steering-council-update/21920
+- Review todo list for EC
+- Review Survey to the EC/SSC about JupyterCon
+    - Ask EC/SSC members to plan for opportunities for a joint leadership meeting @ JupyterCon.
+    - Reviewing options for offering financial travel support.
+- Worked on the DEI Committee Charter
+
+---
+
+## 14 February 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Afshin Darian
+- Fernando Perez
+- Brian Granger
+- Jason Grout
+- Steven Silvester
+
+### Decisions made
+- Code of Conduct incident response:
+    - We have an action item to establish the Code of Conduct incident response Standing Committee.
+    - While we work through that, we reviewed the existing incident response email and Google forms to ensure they are being sent to the Executive Council in the meantime.
+- Need to finalize finance review of overall financial resources so we can prioritize decisions.
+
+### Agenda and minutes
+- COC: reviewed processes for submitting issues and tested emails to `conduct@jupyter.org`
+- Reviewed various Google Drives at NF and better organized content
+
+---
+
+## 7 Feburary 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steve Silvester
+- Afshin Darian
+- Brian Granger
+- Fernando Perez
+
+### Agenda and minutes
+- Prioritization, agenda management, and other logistics discussion
+    - We are starting to use the RICE prioritization framework to prioritize our projects and to-do items.
+- Future JupyterCon agenda proposal - there is value in establishing communication with the community through JupyterCon for the new structure, how should we reflect it in the conference?
+
+---
+
+## 31 January 2023
+
+### Attendees
+- Jason Grout
+- Ana Ruvalcaba
+- Steve Silvester
+- Afshin Darian
+- Brian Granger
+- Fernando Perez
+
+### Agenda and minutes
+- Incubation process and contrib orgs
+    - There is ongoing confusion about the contrib (jupyterlab-contrib) orgs that we need to address.
+    - Obviously, anyone is free to do open source work outside of Jupyter. However, the jupyterlab-contrib org is owned by JupyterLab Council members, official Jupyter work is being done there, and council members are recommending that early stage JupyterLab and Jupyter Server work be done there.
+        - For example, https://github.com/jupyterlab-contrib/jupyter-ui-toolkit has been approved by the JupyterLab council as the official UI toolkit for JupyterLab
+        - See https://github.com/jupyterlab/team-compass/issues/172 for another example.
+    - Essentially, jupyterlab-contrib is functioning as an incubator org for JupyterLab, and this is confusing users and developers.
+    - The confusion is problematic as jupyterlab-contrib has no code-of-conduct, no governance, and some Jupyter contributors can’t (legally) contribute to jupyterlab-contrib.
+    - The root cause is that the Jupyter incubator program is essentially dormant/dead.
+    - Reviving the incubator program and figuring out what to do with the contrib orgs would be a great thing for the SSC to dive into.
+    - https://github.com/jupyter-incubator - an official place in Project Jupyter for incubating projects, listed in the governance docs
+- Creating opportunities for EC+SSC to meet
+    - Fundraising
+    - JupyterCon in-person meeting for EC+SSC
+        - Starting point would be to define a set of desired outcomes / agenda, we can then decide how much time we need and what format would be best
+        - Should be after, not before
+        - Hopefully not during sprints, as the SSC members may really want to be at the sprints
+
+---
+
+## 24 January 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Steve Silvester
+- Afshin Darian
+- Jason Grout
+- Brian Granger
+
+### Decisions made
+    - EC Project Management using a shared spreadsheet
+    - We will have a public team compass repository with publishable meeting minutes
+
+### Agenda and minutes
+- SSC Meeting: Creating opportunities for EC+SSC to meet
+    - Fundraising
+    - JupyterCon in-person meeting for EC+SSC
+        - Starting point would be to define a set of desired outcomes / agenda, we can then decide how much time we need and what format would be best
+        - Should be after, not before
+        - Hopefully not during sprints, as the SSC members may really want to be at the sprints
+        - Maybe have dinner one of the nights
+        - Maybe have the afternoon of Tuesday, then dinner Tuesday night?
+        - Because of COVID, consider making the dinner outdoors
+- Have another regular meeting. 1 day of EC+SSC, then one or two days of broader Union of Councils meetings. Perhaps one day for subproject councils to meet (there there is lots of overlap)
+- Suppose we fundraise to have each subproject council to meet once a year?
+
+---
+
+## 17 January 2023
+
+### Attendees:
+- Steve Silvester
+- Afshin Darian
+- Jason Grout
+- Fernando Perez
+
+### Decisions made
+- Social media team
+    - Should it be a working group?
+        - Steve, Darian, Jason: Yes
+    - Should it have an SSC rep?
+        - Steve, Darian, Jason: No
+
+### Agenda/Minutes
+- SSC formation
+    - Worked on an agenda for first joint meeting of the SSC and EC
+- Code of conduct
+    - Discussion on charter draft
+- Bootstrapping working groups
+    - We think of 2-3 key people that we invite, then let them grow that team themselves
+    - Create a draft charter to have some idea of scope, like 80% done with major things outlined. This charter is committed to the governance docs with a note that it is a draft.
+    - Let the initial people finalize the charter in conjunction with the EC, say over the first 6 months
+- Discussion on social media team charter
+
+---
+
+## 11 January 2023
+
+### Attendees
+- Darian
+- Brian
+- Jason
+- Steve
+- Fernando
+- Sylvain
+
+### Decisions made
+- We will record decisions in a new “Decisions made” section of the meeting minutes to keep things lightweight, but explicit.
+- We created a separate document for the meeting minutes of the EC Office Hours.
+
+### Agenda/Minutes
+- Announcing EC formation
+    - Fernando sent an email to the existing Steering Council announcing.
+    - Worked on [blog post](https://blog.jupyter.org/announcing-a-new-jupyter-governance-model-and-our-first-executive-council-39b3989dc064) draft
+- How can we help the SSC to organize?
+    - Schedule joint EC + SSC meeting where we can talk about the purpose of SSC
+- Default meeting transparency: Anyone can attend, but we ask non-council members to ask their questions in chat
+    - If we need formal structure, we can perhaps use the zoom webinars with council members as panelists
+- Governance related repos/orgs
+    - Auditing access to repos/orgs
+    - New repo for the EC?
+- Social media strategy (prompted by https://github.com/jupyter/governance/issues/146 and mastodon conversation)
+- Jupyter domain
+    - Can we use the jupyter.org domain with the NumFOCUS Google Suite?

--- a/docs/meeting_notes/2023_Q2.md
+++ b/docs/meeting_notes/2023_Q2.md
@@ -1,0 +1,99 @@
+# Meeting Notes from 2023 Q2
+
+## 2 May 2023
+
+### Attendees
+- Jason Grout
+- Fernando Perez
+- Steve Silvester
+- Brian Granger
+- Afshin Darian
+- Ana Ruvalcaba
+
+### Decisions made
+- EC-funded travel to JupyterCon should be pulled from CBC Account
+
+### Agenda and minutes
+- Review Team Todo List
+- Review Team Compass - no new issues
+- Review emails to EC Google Group - no new emails
+- Work on JupyterCon talk
+- Follow up on Notebook 7 blog post
+
+---
+
+## 25 April 2023
+
+### Attendees
+- Fernando Perez
+- Afshin T. Darian
+- Steven Silvester
+- Ana Ruvalcaba
+- Brian Granger
+- Jason Grout
+
+### Decisions made
+- Sync with Notebook Subproject about vision of Jupyter Notebook talk and blog post
+
+### Agenda and minutes
+- Review team compass
+- Review emails to EC Google Group
+- JupyterCon in-person meeting planning
+- Media Relations topics and draft charter iteration
+- JupyterCon talk - continued to work on content ideas
+
+---
+
+## 18 April 2023
+
+### Attendees
+- Afshin T. Darian
+- Brian Granger
+- Steven Silvester
+- Jason Grout
+- Ana Ruvalcaba
+
+### Agenda and minutes
+- EC/SSC meeting(s) agenda
+- Worked on the media relations working group charter draft
+
+---
+
+## 11 April 2023
+
+### Attendees
+- Jason Grout
+- Fernando Perez
+- Afshin T. Darian
+- Ana Ruvalcaba
+- Brian Granger
+
+### Agenda and minutes
+- EC/SSC meeting(s) agenda
+- JupyterCon talk - iterate on content ideas
+
+---
+
+## 4 April 2023
+
+### Attendees
+- Afshin T. Darian
+- Ana Ruvalcaba
+- Steven Silvester
+- Fernando Perez
+- Jason Grout
+- Brian Granger
+
+### Decisions made
+- CoC: we'll work toward the goals of:
+    - Using the NF CoC documents for in-person events as much as possible.
+    - Will review them to see what differences we may have and provide NF feedback as appropriate.
+    - Then we'd try to update our online activity CoC to be derived from this one.
+
+### Agenda and minutes
+- COC update and review
+- Jupyter Communications Working Group draft charter review
+- Mission, Vision, Values review
+
+
+

--- a/docs/office_hours/2023_Q1.md
+++ b/docs/office_hours/2023_Q1.md
@@ -1,0 +1,236 @@
+# Meeting Notes from 2023 Q1
+
+## March 23 2023
+
+### Attendees
+- Brian E Granger
+- Afshin T. Darian
+- Sylvain Corlay
+- Jason Weill
+- Jason Grout
+
+### Agenda and minutes
+- Review and discuss Mission, Vision, Values draft
+- Discuss recent work and blog post on Jupyter AI
+- Social media working group update
+
+---
+
+## 28 Feb 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Jason Weill
+- Steve Silvester
+- A. T. Darian
+- Andrii Ieroshenko
+- Fernando Pérez
+
+### Agenda and minutes
+- JupyterCon updates:
+    - GitHub keynote
+        - We would love to highlight the work of one or more members of the Jupyter community that takes place on GitHub. Are there any particular projects you would like us to highlight that show off the power of Jupyter to bring a community of people together around data that we could include in our talk?
+        - Consider Serena’s work in the Musculoskeletal Imaging Research community https://blog.jupyter.org/report-on-the-jupyter-community-workshop-77016ab1d49b
+- Generative AI in Jupyter blog post outline for discussion
+    - EC members who are interested (Fernando and Darian) will give feedback
+    - 800 - 1000 is the ideal length for a blog post so multiple articles are probably needed to fully address the topic - the ethical framing of this topic is the most critical one. It’s important to address this topic but it’s more important to get the message right rather than soon.
+    - Define what is the CTA for this blog? What is the goal of the post?
+- Office hours changes/updates
+    - Thursdays at 10am Pacific starting on March 23
+    - Canceled for the next two weeks, alternating to every other week
+    - EC may need to use a different channel to not conflict with the Juptyer triage meeting
+
+
+
+
+
+---
+
+## 21 Feb 2023
+
+### Attendees
+- Jason Weill
+- Jason Grout
+- Steve Silvester
+- Ana Ruvalcaba
+- Sharan Foga
+- Sylvain Corlay
+- Fernando Perez
+
+### Agenda and minutes
+- Generative AI blog post update
+- Martha submitted a (draft) PR for the DEI standing committee: https://github.com/jupyter/governance/pull/160
+
+---
+
+## 14 Feb 2023
+
+### Attendees
+- No community participants
+
+---
+
+## 7 Feb 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Matthias Bussonnier
+
+### Agenda and minutes
+- Security/Tidelift/Numfocus: As you may remember I (Matthias) signed with tidelift for IPython/Traitlet - we have/had our first vulnerability via tidelift, not critical. Would it be possible to check with NF if they actually receive Tidelift money. It is still unclear to me. It was originally asked for this money to go to a “security specific” sub account.
+- JupyterCon
+    - Discussion surrounding the “official” Jupyter voice at the conference
+    - Talks by JupyterHub, JupyterLab, and Jupyter Notebook
+    - Governance/EC update
+    - Lightning talks batched together by official subprojects
+    - Official messaging can be communicated through electronic signage at the venue. Deadline for content TBD.
+    - 3 large auditoriums and 8 small classrooms (too small for tracks)
+
+---
+
+## 31 Jan 2023
+
+### Attendees
+- ???
+
+### Agenda and minutes
+- The EC mentioned a couple of weeks ago that to contact them opening an issue on one of the governance repo was a proper method of contact. This can be found on the EC page.  I don’t think this is the case, as https://github.com/jupyter/jupyter.github.io/pull/718 was not replied to.
+    - merged
+- The above mentioned page, “Email the EC mailing list (this list is private but open for posting)”. But I can’t find the email to the executive council easily.
+    - fixed in https://github.com/jupyter/governance/pull/155, now deployed.
+- I suggest that those EC office hours meeting (or the previous hour) have an agenda item of checking:
+    - The governance repo for new/unreplied issues.
+    - The google group for new/unreplied issues.
+- JupyterCon Check In
+- Jupyter incubator in the short term: https://github.com/jupyterlab/team-compass/issues/172
+- These are the docs that govern this today:
+    - https://github.com/jupyter-incubator/proposals
+    - https://github.com/jupyter/governance/blob/main/newsubprojects.md
+- Aspects that need to be updated:
+    - How CoC is handled.
+    - SSC instead of SC as decision-making body.
+    - How to handle “SC sponsor” aspect.
+    - Who is the decision making body for each incubated project?
+    - What to do about incubator projects that are bit rotting (sparkmagic)?
+    - Do we need to renaming this program to attract more contributions (e.g. from jupyterlab-contrib).
+    - What is the eventual home for the repo?
+
+---
+
+## 24 Jan 2023
+
+### Attendees
+- Ana Ruvalcaba
+- Jason Grout
+- Steve Silvester
+- Matthias Bussonnier
+- Brian Granger
+- Afshin Darian
+- Fernando Pérez
+- Jason Weill
+
+### Agenda and minutes
+
+- Jupyter generative AI project
+    - This brings up the question: Does Jupyter have an ethical or social responsibility around AI tools in Jupyter. Should Jupyter have disclaimers or warnings to users around these tools?
+    - These tools often already have guard rails and disclaimers themselves
+    - Jupyter does not inherently have a hosting service, so does not have to worry about policies around hosting user content
+    - Perhaps we add metadata (or encourage adding metadata) around the generated content
+    - Is there a blog post in this? (Jason G. - yes, a blog post is about sparking community discussion, and we definitely could use some community discussion and conventions around this)
+    - The AWS version of Copilot has some information about the sources
+    - Perhaps we automate inserting metadata around the ai-generated content. Having an official package as a framework for using these services makes it easy to uniformly insert metadata.
+    - The heart of Jupyter is talking to humans in prose and computers in code, but now we have another interactive computing partner. It's very much in the scope and experience of Jupyter. We should embrace this critically.
+- Notes about governance transition
+    - Some people seem to not have seen the new EC announcement, either on discourse, or on the blog.
+    - Did we email the union of councils with the results? Jason Grout doesn't see an email to various council lists.
+    - We will send such an email pointing people to the blog post.
+    - We should repeat the message and tweet occasionally, we can also pin the message to the top
+    - EC can also promote it in their social media channels: either Twitter or LinkedIn that links to the post, that will drive traffic to the announcement
+- Consolidation of GitHub’s Jupyter’s Org.
+    - Perhaps we have multiple orgs, but please not 13
+    - Perhaps this a good question for the SSC to consider?
+    - Please stop creating new github orgs until we figure this out
+- Security bug bounty program offer
+    - Email sent out to the subproject council lists to ask which subprojects would like to participate in a security bug bounty program funded by the European Commission, run by the Intigriti platform.
+- JupyterCon update
+    - Finishing reviews of talks
+    - 152 proposals. Around 70 spots or so.
+    - Keynote speakers and ticket prices are announced
+    - Tutorials are still sort of unclear - we invited tutorial speakers, and looking at funding travel for tutorials
+= Security: the security team is overwhelmed, and barely have time to respond to questions
+
+
+
+
+
+
+---
+
+## 17 Jan 2023
+
+### Attendees
+- Matthias Bussonnier
+- Jason Grout
+- Jason Weill
+- Sharan Foga
+- Steve Silvester
+- Fernando Pérez
+- Afshin Darian
+
+### Agenda and minutes
+- JupyterCon
+    - Several keynote speakers are lined up, announced soon
+    - There is a rough plan for official subproject updates to the community
+    - Rough idea: gather in the morning, then split for tracks, lunch, split for tracks, then come back together before dinner. The afternoon gatherings might be a poster session, keynote, official project updates, etc.
+    - Sprints probably Saturday and Sunday, so we are less reluctant to schedule things on Friday
+    - CZI is launching an initiative on open source in Latin America - see Fernando about this and the building momentum in Latin America around open source
+- Social media team
+    - https://discourse.jupyter.org/t/monitoring-of-mentions-on-twitter/17427
+        - Expectation is often that people can get a response, even a redirecting one (please go to this URL) when contacting an official account on social media
+        - EC response to this thread: we're drafting on a charter for a new working group
+- Confusion Jupyter/Discourse privacy policy.
+- What is the process to request/ask questions to this committee outside office hours?
+    - Public can post to the EC mailing list right now, but those discussions are not public.
+    - Perhaps the EC has a public channel for discussion, like a team-compass or an issue on the governance repo
+- Transparency reports:
+    - Trademark report (number of enforcement issues, number of requests, etc.)
+    - Community building committee (charter says we'll have yearly public reports, quarterly steering council reports)
+    - Perhaps we have a quarterly report with one paragraph per subproject/working group
+    - Apache has a monthly report from the trademarks org to the board
+    - Apache also has reports from each project that follow a form with specific information
+        - Parquet's reports: https://whimsy.apache.org/board/minutes/Parquet.html
+        - A lot of this information is auto-generated from a tool
+    - Software_subprojects.md said:
+        - Conduct its activities in a manner that is open, transparent, and inclusive. This includes coordinating with the SSC and the Board of Directors on mechanisms for information flow and updates to the broader community (details of this, project-wide, will be developed as our new governance model is adopted and implemented).
+    - EC yearly report
+    - Maybe the SSC is responsible for bugging each projects
+- Purpose for this meeting?
+    - This call is open for any questions people have. If it turns out that there aren't, the EC also has items to discuss
+
+---
+
+## 10 Jan 2023
+
+### Attendees
+- Brian Granger
+- Jason Grout
+- Jason Weill
+- Matthias Bussonnier
+- Fernando Perez
+- Sylvain Corlay
+- Afshin Darian
+- Steve Silvester
+
+### Agenda and minutes
+- Social media strategy (prompted by https://github.com/jupyter/governance/issues/146 and mastodon conversation)
+    - Regular reminder that there is a Jupyter facebook account…
+    - Should we have a social media team?
+        - (not call it committee)
+    - CBC is focused on events (and starting to branch out to strategically building community within subprojects)
+        -   So let’s call it the event team ?
+- Jupyter domain
+    - Can we use the jupyter.org domain with the NumFOCUS Google Suite
+- Intro blog post re: EC
+- Uffizzi (uffizzi.com)  integration w/JupyterLab (broader: how do we handle a commercial vendor submitting a PR?)
+    - Unless there is a jlab person that champions this, it's probably better not to do this.
+This is probably a self-contained decision for JupyterLab to take up

--- a/docs/office_hours/2023_Q2.md
+++ b/docs/office_hours/2023_Q2.md
@@ -1,0 +1,40 @@
+# Meeting Notes from 2023 Q1
+
+## 4 May 2023
+
+### Attendees
+- Sylvain Corlay
+- tony fast
+- A. T. Darian
+
+### Agenda and minutes
+- Accessibility of Jupyter Notebook (beyond compliance) and with the use of assistive technologies
+
+---
+
+## 20 April 2023
+
+### Attendees
+- A. T. Darian
+- Ana Ruvalcaba
+- Zach Sailer
+- Brian Granger
+
+### Agenda and minutes
+- Andrii asked about the Notebook 7 blog post and when we can publish it. We discussed the draft.
+    - https://github.com/jupyter/notebook-team-compass/issues/24
+- Zach brought up the SSC work around “schematizing” various parts of the Jupyter stack:
+    - The SSC will write a JEP proposing a jupyter.org subdomain to host schema versions
+
+---
+
+## 6 April 2023
+
+### Attendees
+- Ana
+- Steve
+- Jason W
+
+### Agenda and minutes
+- Waited until the 15-minute mark and didn’t get participants. Since there were not any agenda items and no folks dropping by we left the channel.
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx_book_theme
 pandas
 ruamel.yaml
 myst_parser
+urllib3<2


### PR DESCRIPTION
This PR catches up on the backlog of EC meeting minutes.

Fixes https://github.com/jupyter/executive-council-team-compass/issues/2

### Note
This PR pins `urllib3` to `<2` in `requirements.txt` as a workaround for SSL failures, but we should remove this constraint when it becomes possible.